### PR TITLE
Include WallOfType.Full in HardCodedWallOffPlacement.FindPlacement

### DIFF
--- a/Sharky/Builds/BuildingPlacement/Wall/HardCodedWallOffPlacement.cs
+++ b/Sharky/Builds/BuildingPlacement/Wall/HardCodedWallOffPlacement.cs
@@ -35,7 +35,7 @@
             if (baseLocation == null) { return null; }
 
             WallData wallData = null;
-            if (wallOffType == WallOffType.Partial)
+            if (wallOffType == WallOffType.Partial || wallOffType == WallOffType.Full)
             {
                 wallData = MapData.WallData.FirstOrDefault(b => b.BasePosition.X == baseLocation.X && b.BasePosition.Y == baseLocation.Y);
                 if (wallData == null) { return null; }


### PR DESCRIPTION
I am pretty sure that wallData should also be set up in the case of a full wall, not only in the case of partial or Terran. Let me know if you disagree.