### PR TITLE
Allow updating the micro controller for a specific unit type in the attack task

### DIFF
--- a/Sharky/MicroControllers/AdvancedMicroController.cs
+++ b/Sharky/MicroControllers/AdvancedMicroController.cs
@@ -447,5 +447,10 @@ namespace Sharky.MicroControllers
                 }
             }
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Sharky/MicroControllers/IMicroController.cs
+++ b/Sharky/MicroControllers/IMicroController.cs
@@ -8,5 +8,6 @@
         List<SC2Action> Contain(IEnumerable<UnitCommander> commanders, Point2D target, Point2D defensivePoint, Point2D groupCenter, int frame);
         List<SC2Action> Support(IEnumerable<UnitCommander> commanders, IEnumerable<UnitCommander> supportTargets, Point2D target, Point2D defensivePoint, Point2D groupCenter, int frame);
         List<SC2Action> Idle(IEnumerable<UnitCommander> commanders, Point2D target, Point2D defensivePoint, int frame);
+        void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController);
     }
 }

--- a/Sharky/MicroControllers/MicroController.cs
+++ b/Sharky/MicroControllers/MicroController.cs
@@ -201,5 +201,10 @@
             }
             return actions;
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            MicroData.IndividualMicroControllers[unitType] = microController;
+        }
     }
 }

--- a/Sharky/MicroControllers/Protoss/PhoenixGroupMicroController.cs
+++ b/Sharky/MicroControllers/Protoss/PhoenixGroupMicroController.cs
@@ -251,5 +251,10 @@
         {
             return Attack(commanders, target, defensivePoint, groupCenter, frame);
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Sharky/MicroControllers/Terran/BansheeGroupMicroController.cs
+++ b/Sharky/MicroControllers/Terran/BansheeGroupMicroController.cs
@@ -245,5 +245,10 @@
         {
             return Attack(commanders, target, defensivePoint, groupCenter, frame);
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Sharky/MicroControllers/Zerg/MutaliskGroupMicroController.cs
+++ b/Sharky/MicroControllers/Zerg/MutaliskGroupMicroController.cs
@@ -237,5 +237,10 @@
         {
             return Attack(commanders, target, defensivePoint, groupCenter, frame);
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Sharky/MicroTasks/Attack/AttackTask.cs
+++ b/Sharky/MicroTasks/Attack/AttackTask.cs
@@ -143,5 +143,10 @@
                 return actions;
             }
         }
+
+        public void UpdateUnitMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            MicroController.UpdateUnitMicroController(unitType, microController);
+        }
     }
 }

--- a/Sharky/SharkyData/MicroTaskData.cs
+++ b/Sharky/SharkyData/MicroTaskData.cs
@@ -14,5 +14,16 @@
                 microTask.Value.StealUnit(commander);
             }
         }
+
+        /// <summary>
+        /// Assigns a new micro controller for a unit in the attack task
+        /// </summary>
+        public void UpdateAttackMicroController(UnitTypes unitType, IIndividualMicroController microController)
+        {
+            if (this.GetValueOrDefault("AttackTask") is AttackTask attackTask)
+            {
+                attackTask.UpdateUnitMicroController(unitType, microController);
+            }
+        }
     }
 }


### PR DESCRIPTION
I am not sure if you want this in the main repo but I find it useful to be able to swap out the micro controller for a specific unit type based on game developments (e.g. enemy unit composition or certain upgrades like Charge).