### PR TITLE
Small fix in ProtossBuildingPlacement 

### DIFF
--- a/Sharky/Builds/BuildingPlacement/Protoss/ProtossBuildingPlacement.cs
+++ b/Sharky/Builds/BuildingPlacement/Protoss/ProtossBuildingPlacement.cs
@@ -314,7 +314,7 @@
                                     {
                                         if (!requireSameHeight || MapDataService.MapHeight(point) == startHeight)
                                         {
-                                            if (!LastLocations.Any(l => l.X == x && l.Y == y))
+                                            if (!LastLocations.Contains(point))
                                             {
                                                 DebugService.DrawSphere(new Point { X = point.X, Y = point.Y, Z = 12 });
 


### PR DESCRIPTION
I am pretty sure that LastLocations in ProtossBuildingPlacement should be compared to the building location, not the pylon location. Otherwise it will keep trying the location that didn't work.